### PR TITLE
native-activity: Fix InputAvailable support

### DIFF
--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -379,7 +379,7 @@ impl AndroidAppInner {
             return None;
         }
         let cstr = unsafe {
-            let cstr_slice = CStr::from_ptr(path);
+            let cstr_slice = CStr::from_ptr(path.cast());
             cstr_slice.to_str().ok()?
         };
         if cstr.len() == 0 {

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -412,7 +412,7 @@ impl AndroidAppInner {
             return None;
         }
         let cstr = unsafe {
-            let cstr_slice = CStr::from_ptr(path);
+            let cstr_slice = CStr::from_ptr(path.cast());
             cstr_slice.to_str().ok()?
         };
         if cstr.len() == 0 {

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -72,7 +72,7 @@ impl<'a> StateSaver<'a> {
             }
 
             (*app_ptr).savedState = buf;
-            (*app_ptr).savedStateSize = state.len() as u64;
+            (*app_ptr).savedStateSize = state.len() as _;
         }
     }
 }

--- a/examples/agdk-egui/Cargo.toml
+++ b/examples/agdk-egui/Cargo.toml
@@ -45,6 +45,11 @@ env_logger = "0.9"
 android_logger = "0.11.0"
 android-activity = { path="../../android-activity", features = [ "game-activity" ] }
 
+# Since Winit also depends on android-activity (via a github url) we need to
+# make sure we only resolve a single implementation.
+[patch.'https://github.com/rib/android-activity']
+android-activity = { path="../../android-activity", features = [ "game-activity" ] }
+
 [features]
 default = []
 desktop = []

--- a/examples/agdk-winit-wgpu/Cargo.toml
+++ b/examples/agdk-winit-wgpu/Cargo.toml
@@ -19,6 +19,11 @@ env_logger = "0.9"
 android_logger = "0.11.0"
 android-activity = { path="../../android-activity", features = [ "game-activity" ] }
 
+# Since Winit also depends on android-activity (via a github url) we need to
+# make sure we only resolve a single implementation.
+[patch.'https://github.com/rib/android-activity']
+android-activity = { path="../../android-activity", features = [ "game-activity" ] }
+
 [features]
 default = []
 desktop = []

--- a/examples/na-mainloop/src/lib.rs
+++ b/examples/na-mainloop/src/lib.rs
@@ -11,7 +11,7 @@ fn android_main(app: AndroidApp) {
 
     while !quit {
         app.poll_events(
-            Some(std::time::Duration::from_millis(500)), /* timeout */
+            Some(std::time::Duration::from_secs(1)), /* timeout */
             |event| {
                 match event {
                     PollEvent::Wake => {
@@ -47,6 +47,9 @@ fn android_main(app: AndroidApp) {
                                 redraw_pending = true;
                             }
                             MainEvent::RedrawNeeded { .. } => {
+                                redraw_pending = true;
+                            }
+                            MainEvent::InputAvailable { .. } => {
                                 redraw_pending = true;
                             }
                             MainEvent::LowMemory => {}

--- a/examples/na-winit-wgpu/Cargo.toml
+++ b/examples/na-winit-wgpu/Cargo.toml
@@ -19,6 +19,11 @@ env_logger = "0.9"
 android_logger = "0.11.0"
 android-activity = { path="../../android-activity", features = [ "native-activity" ] }
 
+# Since Winit also depends on android-activity (via a github url) we need to
+# make sure we only resolve a single implementation.
+[patch.'https://github.com/rib/android-activity']
+android-activity = { path="../../android-activity", features = [ "native-activity" ] }
+
 [features]
 default = []
 desktop = []


### PR DESCRIPTION
"native-activity" builds were recently broken by bb8eeb705c which
this patch fixes.

The na-mainloop example has also been updated to verify this by
reducing the fake "render" timeout and also triggering a fake
render when an InputAvailable event is received.

Fixes: #12