### PR TITLE
Api cleanup for winit

### DIFF
--- a/android-activity/CHANGELOG.md
+++ b/android-activity/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AndroidApp` is now `Send` + `Sync`
 ### Changed
 - *Breaking*: updates to `ndk 0.7` and `ndk-sys 0.4`
+- *Breaking*: `AndroidApp::config()` now returns a clonable `ConfigurationRef` instead of a deep `Configuration` copy
 
 ## [0.1.1] - 2022-07-04
 ### Changed

--- a/android-activity/CHANGELOG.md
+++ b/android-activity/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Emit an `InputAvailable` event for new input with `NativeActivity` and `GameActivity`
   enabling gui apps that don't render continuously
 - Oboe and Cpal audio examples added
+- `AndroidApp` is now `Send` + `Sync`
 ### Changed
 - *Breaking*: updates to `ndk 0.7` and `ndk-sys 0.4`
 

--- a/android-activity/CHANGELOG.md
+++ b/android-activity/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - *Breaking*: updates to `ndk 0.7` and `ndk-sys 0.4`
 - *Breaking*: `AndroidApp::config()` now returns a clonable `ConfigurationRef` instead of a deep `Configuration` copy
+### Removed
+- The `NativeWindowRef` wrapper struct was removed since `NativeWindow` now implements `Clone` and `Drop` in `ndk 0.7`
 
 ## [0.1.1] - 2022-07-04
 ### Changed

--- a/android-activity/CHANGELOG.md
+++ b/android-activity/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *Breaking*: `AndroidApp::config()` now returns a clonable `ConfigurationRef` instead of a deep `Configuration` copy
 ### Removed
 - The `NativeWindowRef` wrapper struct was removed since `NativeWindow` now implements `Clone` and `Drop` in `ndk 0.7`
+- *Breaking*: The `FdEvent` and `Error` enum values were removed from `PollEvents`
 
 ## [0.1.1] - 2022-07-04
 ### Changed

--- a/android-activity/src/config.rs
+++ b/android-activity/src/config.rs
@@ -1,0 +1,144 @@
+use core::fmt;
+use std::sync::{Arc, RwLock};
+
+use ndk::configuration::{
+    Configuration, Keyboard, KeysHidden, LayoutDir, NavHidden, Navigation, Orientation, ScreenLong,
+    ScreenSize, Touchscreen, UiModeNight, UiModeType,
+};
+
+#[derive(Clone)]
+pub struct ConfigurationRef {
+    config: Arc<RwLock<Configuration>>,
+}
+impl PartialEq for ConfigurationRef {
+    fn eq(&self, other: &Self) -> bool {
+        if Arc::ptr_eq(&self.config, &other.config) {
+            true
+        } else {
+            let other_guard = other.config.read().unwrap();
+            self.config.read().unwrap().eq(&*other_guard)
+        }
+    }
+}
+impl Eq for ConfigurationRef {}
+unsafe impl Send for ConfigurationRef {}
+unsafe impl Sync for ConfigurationRef {}
+
+impl fmt::Debug for ConfigurationRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.config.read().unwrap().fmt(f)
+    }
+}
+
+impl ConfigurationRef {
+    pub(crate) fn new(config: Configuration) -> Self {
+        Self {
+            config: Arc::new(RwLock::new(config)),
+        }
+    }
+
+    pub(crate) fn replace(&self, src: Configuration) {
+        self.config.write().unwrap().copy(&src);
+    }
+
+    // Returns a deep copy of the full application configuration
+    pub fn copy(&self) -> Configuration {
+        let mut dest = Configuration::new();
+        dest.copy(&self.config.read().unwrap());
+        dest
+    }
+    /// Returns the country code, as a [`String`] of two characters, if set
+    pub fn country(&self) -> Option<String> {
+        self.config.read().unwrap().country()
+    }
+
+    /// Returns the screen density in dpi.
+    ///
+    /// On some devices it can return values outside of the density enum.
+    pub fn density(&self) -> Option<u32> {
+        self.config.read().unwrap().density()
+    }
+
+    /// Returns the keyboard type.
+    pub fn keyboard(&self) -> Keyboard {
+        self.config.read().unwrap().keyboard()
+    }
+
+    /// Returns keyboard visibility/availability.
+    pub fn keys_hidden(&self) -> KeysHidden {
+        self.config.read().unwrap().keys_hidden()
+    }
+
+    /// Returns the language, as a `String` of two characters, if a language is set
+    pub fn language(&self) -> Option<String> {
+        self.config.read().unwrap().language()
+    }
+
+    /// Returns the layout direction
+    pub fn layout_direction(&self) -> LayoutDir {
+        self.config.read().unwrap().layout_direction()
+    }
+
+    /// Returns the mobile country code.
+    pub fn mcc(&self) -> i32 {
+        self.config.read().unwrap().mcc()
+    }
+
+    /// Returns the mobile network code, if one is defined
+    pub fn mnc(&self) -> Option<i32> {
+        self.config.read().unwrap().mnc()
+    }
+
+    pub fn nav_hidden(&self) -> NavHidden {
+        self.config.read().unwrap().nav_hidden()
+    }
+
+    pub fn navigation(&self) -> Navigation {
+        self.config.read().unwrap().navigation()
+    }
+
+    pub fn orientation(&self) -> Orientation {
+        self.config.read().unwrap().orientation()
+    }
+
+    pub fn screen_height_dp(&self) -> Option<i32> {
+        self.config.read().unwrap().screen_height_dp()
+    }
+
+    pub fn screen_width_dp(&self) -> Option<i32> {
+        self.config.read().unwrap().screen_width_dp()
+    }
+
+    pub fn screen_long(&self) -> ScreenLong {
+        self.config.read().unwrap().screen_long()
+    }
+
+    #[cfg(feature = "api-level-30")]
+    pub fn screen_round(&self) -> ScreenRound {
+        self.config.read().unwrap().screen_round()
+    }
+
+    pub fn screen_size(&self) -> ScreenSize {
+        self.config.read().unwrap().screen_size()
+    }
+
+    pub fn sdk_version(&self) -> i32 {
+        self.config.read().unwrap().sdk_version()
+    }
+
+    pub fn smallest_screen_width_dp(&self) -> Option<i32> {
+        self.config.read().unwrap().smallest_screen_width_dp()
+    }
+
+    pub fn touchscreen(&self) -> Touchscreen {
+        self.config.read().unwrap().touchscreen()
+    }
+
+    pub fn ui_mode_night(&self) -> UiModeNight {
+        self.config.read().unwrap().ui_mode_night()
+    }
+
+    pub fn ui_mode_type(&self) -> UiModeType {
+        self.config.read().unwrap().ui_mode_type()
+    }
+}

--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -24,7 +24,7 @@ use ndk::configuration::Configuration;
 use ndk::looper::FdEvent;
 use ndk::native_window::NativeWindow;
 
-use crate::{util, AndroidApp, ConfigurationRef, MainEvent, NativeWindowRef, PollEvent, Rect};
+use crate::{util, AndroidApp, ConfigurationRef, MainEvent, PollEvent, Rect};
 
 mod ffi;
 
@@ -154,13 +154,8 @@ pub struct AndroidAppInner {
 }
 
 impl AndroidAppInner {
-    pub fn native_window<'a>(&self) -> Option<NativeWindowRef> {
-        let guard = self.native_window.read().unwrap();
-        if let Some(ref window) = *guard {
-            Some(NativeWindowRef::new(window))
-        } else {
-            None
-        }
+    pub fn native_window<'a>(&self) -> Option<NativeWindow> {
+        self.native_window.read().unwrap().clone()
     }
 
     pub fn poll_events<F>(&self, timeout: Option<Duration>, mut callback: F)

--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -241,7 +241,7 @@ impl AndroidAppInner {
                                         MainEvent::RedrawNeeded {}
                                     }
                                     ffi::NativeAppGlueAppCmd_APP_CMD_CONTENT_RECT_CHANGED => {
-                                        MainEvent::ContentRectChanged
+                                        MainEvent::ContentRectChanged {}
                                     }
                                     ffi::NativeAppGlueAppCmd_APP_CMD_GAINED_FOCUS => {
                                         MainEvent::GainedFocus

--- a/android-activity/src/lib.rs
+++ b/android-activity/src/lib.rs
@@ -65,12 +65,6 @@ pub enum MainEvent<'a> {
     /// redundant event loop wake ups._
     ///
     /// [`AndroidApp::input_events()`]: AndroidApp::input_events
-    ///
-    /// # Portability
-    ///
-    /// This is currently only supported with `NativeActivity` with the
-    /// "native-activity" feature. Applications using `GameActivity` should
-    /// continue to check for input as part of their rendering updates.
     InputAvailable,
 
     /// Command from main thread: a new [`NativeWindow`] is ready for use.  Upon

--- a/android-activity/src/lib.rs
+++ b/android-activity/src/lib.rs
@@ -137,7 +137,8 @@ pub enum MainEvent<'a> {
     /// Command from main thread: the content area of the window has changed,
     /// such as from the soft input window being shown or hidden.  You can
     /// get the new content rect by calling [`AndroidApp::content_rect()`]
-    ContentRectChanged,
+    #[non_exhaustive]
+    ContentRectChanged {},
 
     /// Command from main thread: the app's activity window has gained
     /// input focus.

--- a/android-activity/src/lib.rs
+++ b/android-activity/src/lib.rs
@@ -1,5 +1,6 @@
 use std::hash::Hash;
 use std::ops::Deref;
+use std::sync::RwLock;
 use std::time::Duration;
 use std::{os::unix::prelude::RawFd, sync::Arc};
 
@@ -207,7 +208,7 @@ pub use activity_impl::AndroidAppWaker;
 
 #[derive(Debug, Clone)]
 pub struct AndroidApp {
-    pub(crate) inner: Arc<AndroidAppInner>,
+    pub(crate) inner: Arc<RwLock<AndroidAppInner>>,
 }
 
 impl PartialEq for AndroidApp {
@@ -227,7 +228,7 @@ impl AndroidApp {
     #[cfg_attr(docsrs, doc(cfg(feature = "native-activity")))]
     #[cfg(feature = "native-activity")]
     pub(crate) fn native_activity(&self) -> *const ndk_sys::ANativeActivity {
-        self.inner.native_activity()
+        self.inner.read().unwrap().native_activity()
     }
 
     /// Queries the current [`NativeWindow`] for the application.
@@ -236,7 +237,7 @@ impl AndroidApp {
     /// [`AndroidAppMainEvent::InitWindow`] and [`AndroidAppMainEvent::TerminateWindow`]
     /// events.
     pub fn native_window<'a>(&self) -> Option<NativeWindowRef> {
-        self.inner.native_window()
+        self.inner.read().unwrap().native_window()
     }
 
     /// Calls [`ALooper_pollAll`] on the looper associated with this AndroidApp as well
@@ -250,14 +251,11 @@ impl AndroidApp {
     /// set to `None` once the callback returns, and this is also synchronized with the Java
     /// main thread. The [`MainEvent::SaveState`] event is also synchronized with the
     /// Java main thread.
-    ///
-    /// # Safety
-    /// This API must only be called from the application's main thread
     pub fn poll_events<F>(&self, timeout: Option<Duration>, callback: F)
     where
         F: FnMut(PollEvent),
     {
-        self.inner.poll_events(timeout, callback);
+        self.inner.read().unwrap().poll_events(timeout, callback);
     }
 
     /// Creates a means to wake up the main loop while it is blocked waiting for
@@ -265,50 +263,41 @@ impl AndroidApp {
     ///
     /// Internally this uses [`ALooper_wake`] on the looper associated with this
     /// [AndroidApp].
-    ///
-    /// # Safety
-    /// This API can be used from any thread
     pub fn create_waker(&self) -> activity_impl::AndroidAppWaker {
-        self.inner.create_waker()
+        self.inner.read().unwrap().create_waker()
     }
 
     /// Returns a deep copy of this application's [`Configuration`]
     pub fn config(&self) -> Configuration {
-        self.inner.config()
+        self.inner.read().unwrap().config()
     }
 
     /// Queries the current content rectangle of the window; this is the area where the
     /// window's content should be placed to be seen by the user.
-    ///
-    /// # Safety
-    /// This API must only be called from the applications main thread
     pub fn content_rect(&self) -> Rect {
-        self.inner.content_rect()
+        self.inner.read().unwrap().content_rect()
     }
 
     /// Queries the Asset Manager instance for the application.
     ///
     /// Use this to access binary assets bundled inside your application's .apk file.
-    ///
-    /// # Safety
-    /// This API must only be called from the applications main thread
     pub fn asset_manager(&self) -> AssetManager {
-        self.inner.asset_manager()
+        self.inner.read().unwrap().asset_manager()
     }
 
     pub fn enable_motion_axis(&self, axis: input::Axis) {
-        self.inner.enable_motion_axis(axis);
+        self.inner.write().unwrap().enable_motion_axis(axis);
     }
 
     pub fn disable_motion_axis(&self, axis: input::Axis) {
-        self.inner.disable_motion_axis(axis);
+        self.inner.write().unwrap().disable_motion_axis(axis);
     }
 
     pub fn input_events<'b, F>(&self, callback: F)
     where
         F: FnMut(&input::InputEvent),
     {
-        self.inner.input_events(callback);
+        self.inner.read().unwrap().input_events(callback);
     }
 
     /// The user-visible SDK version of the framework
@@ -325,16 +314,22 @@ impl AndroidApp {
 
     /// Path to this application's internal data directory
     pub fn internal_data_path(&self) -> Option<std::path::PathBuf> {
-        self.inner.internal_data_path()
+        self.inner.read().unwrap().internal_data_path()
     }
 
     /// Path to this application's external data directory
     pub fn external_data_path(&self) -> Option<std::path::PathBuf> {
-        self.inner.external_data_path()
+        self.inner.read().unwrap().external_data_path()
     }
 
     /// Path to the directory containing the application's OBB files (if any).
     pub fn obb_path(&self) -> Option<std::path::PathBuf> {
-        self.inner.obb_path()
+        self.inner.read().unwrap().obb_path()
     }
+}
+
+#[test]
+fn test_app_is_send_sync() {
+    fn needs_send_sync<T: Send + Sync>() {}
+    needs_send_sync::<AndroidApp>();
 }

--- a/android-activity/src/lib.rs
+++ b/android-activity/src/lib.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use std::{os::unix::prelude::RawFd, sync::Arc};
 
 use ndk::asset::AssetManager;
-use ndk::configuration::Configuration;
 // TODO: import FdEvent and avoid depending on ndk Looper abstraction in case we want to
 // support using epoll directly in the future.
 use ndk::looper::FdEvent;
@@ -35,6 +34,9 @@ mod game_activity;
 use game_activity as activity_impl;
 
 pub use activity_impl::input;
+
+mod config;
+pub use config::ConfigurationRef;
 
 mod util;
 
@@ -148,7 +150,8 @@ pub enum MainEvent<'a> {
     /// Command from main thread: the current device configuration has changed.
     /// You can get a copy of the latest [Configuration] by calling
     /// [`AndroidApp::config()`]
-    ConfigChanged,
+    #[non_exhaustive]
+    ConfigChanged {},
 
     /// Command from main thread: the system is running low on memory.
     /// Try to reduce your memory use.
@@ -267,8 +270,8 @@ impl AndroidApp {
         self.inner.read().unwrap().create_waker()
     }
 
-    /// Returns a deep copy of this application's [`Configuration`]
-    pub fn config(&self) -> Configuration {
+    /// Returns a (cheaply clonable) reference to this application's [`Configuration`]
+    pub fn config(&self) -> ConfigurationRef {
         self.inner.read().unwrap().config()
     }
 

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -22,7 +22,7 @@ use ndk::input_queue::InputQueue;
 use ndk::looper::FdEvent;
 use ndk::native_window::NativeWindow;
 
-use crate::{util, AndroidApp, ConfigurationRef, MainEvent, NativeWindowRef, PollEvent, Rect};
+use crate::{util, AndroidApp, ConfigurationRef, MainEvent, PollEvent, Rect};
 
 mod ffi;
 
@@ -163,13 +163,8 @@ impl AndroidAppInner {
         }
     }
 
-    pub fn native_window<'a>(&self) -> Option<NativeWindowRef> {
-        let guard = self.native_window.read().unwrap();
-        if let Some(ref window) = *guard {
-            Some(NativeWindowRef::new(window))
-        } else {
-            None
-        }
+    pub fn native_window<'a>(&self) -> Option<NativeWindow> {
+        self.native_window.read().unwrap().clone()
     }
 
     pub fn poll_events<F>(&self, timeout: Option<Duration>, mut callback: F)

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -19,7 +19,6 @@ use ndk_sys::{ALooper, ALooper_pollAll};
 use ndk::asset::AssetManager;
 use ndk::configuration::Configuration;
 use ndk::input_queue::InputQueue;
-use ndk::looper::FdEvent;
 use ndk::native_window::NativeWindow;
 
 use crate::{util, AndroidApp, ConfigurationRef, MainEvent, PollEvent, Rect};
@@ -208,14 +207,9 @@ impl AndroidAppInner {
                     callback(PollEvent::Timeout);
                 }
                 ffi::ALOOPER_POLL_ERROR => {
-                    trace!("ALooper_pollAll returned POLL_ERROR");
-                    callback(PollEvent::Error);
-
-                    // Considering that this API is quite likely to be used in `android_main`
-                    // it's rather unergonomic to require the call to unwrap a Result for each
-                    // call to poll_events(). Alternatively we could maybe even just panic!()
-                    // here, while it's hard to imagine practically being able to recover
-                    //return Err(LooperError);
+                    // If we have an IO error with our pipe to the main Java thread that's surely
+                    // not something we can recover from
+                    panic!("ALooper_pollAll returned POLL_ERROR");
                 }
                 id if id >= 0 => {
                     match id as u32 {
@@ -313,17 +307,7 @@ impl AndroidAppInner {
                             callback(PollEvent::Main(MainEvent::InputAvailable))
                         }
                         _ => {
-                            let events = FdEvent::from_bits(events as u32).expect(&format!(
-                                "Spurious ALooper_pollAll event flags {:#04x}",
-                                events as u32
-                            ));
-                            trace!("Custom ALooper event source: id = {id}, fd = {fd}, events = {events:?}, data = {source:?}");
-                            callback(PollEvent::FdEvent {
-                                ident: id,
-                                fd: fd as RawFd,
-                                events,
-                                data: source,
-                            });
+                            error!("Ignoring spurious ALooper event source: id = {id}, fd = {fd}, events = {events:?}, data = {source:?}");
                         }
                     }
                 }

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -245,7 +245,7 @@ impl AndroidAppInner {
                                         Some(MainEvent::RedrawNeeded {})
                                     }
                                     ffi::APP_CMD_CONTENT_RECT_CHANGED => {
-                                        Some(MainEvent::ContentRectChanged)
+                                        Some(MainEvent::ContentRectChanged {})
                                     }
                                     ffi::APP_CMD_GAINED_FOCUS => Some(MainEvent::GainedFocus),
                                     ffi::APP_CMD_LOST_FOCUS => Some(MainEvent::LostFocus),

--- a/examples/agdk-egui/.idea/gradle.xml
+++ b/examples/agdk-egui/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/examples/agdk-egui/Cargo.toml
+++ b/examples/agdk-egui/Cargo.toml
@@ -17,7 +17,7 @@ egui-winit = { version = "0.18", default-features = false }
 egui_demo_lib = "0.18"
 
 [patch.crates-io]
-winit = { git = "https://github.com/rib/winit", branch = "android-activity-0.27" }
+winit = { git = "https://github.com/rib/winit", branch = "android-activity-0.27-staging" }
 #winit = { path="../../../winit" }
 
 egui = { git = "https://github.com/budde25/egui", branch = "bump-winit" }

--- a/examples/agdk-mainloop/src/lib.rs
+++ b/examples/agdk-mainloop/src/lib.rs
@@ -52,6 +52,9 @@ fn android_main(app: AndroidApp) {
                             MainEvent::InputAvailable { .. } => {
                                 redraw_pending = true;
                             }
+                            MainEvent::ConfigChanged { .. } => {
+                                info!("Config Changed: {:#?}", app.config());
+                            }
                             MainEvent::LowMemory => {}
 
                             MainEvent::Destroy => quit = true,

--- a/examples/agdk-winit-wgpu/.idea/gradle.xml
+++ b/examples/agdk-winit-wgpu/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/examples/na-mainloop/.idea/gradle.xml
+++ b/examples/na-mainloop/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/examples/na-mainloop/src/lib.rs
+++ b/examples/na-mainloop/src/lib.rs
@@ -52,6 +52,9 @@ fn android_main(app: AndroidApp) {
                             MainEvent::InputAvailable { .. } => {
                                 redraw_pending = true;
                             }
+                            MainEvent::ConfigChanged { .. } => {
+                                info!("Config Changed: {:#?}", app.config());
+                            }
                             MainEvent::LowMemory => {}
 
                             MainEvent::Destroy => quit = true,


### PR DESCRIPTION
A number of API cleanups made while updating the Winit backend and dealing with some TODO items to try and reduce the chance of needing API breakages in the future.

- To make it possible to hold a reference to the AndroidApp within a Winit `Window` or `MonitorHandle` (for access to native_window and config state) the app structure is now `Send` + `Sync`.
- To avoid needing a static global Configuration in the Winit backend it's now possible to access a `ConfigurationRef` which is cheap to clone, Send + Sync and gives access to the application configuration without needing to make deep copies of the large `Configuration` struct
- The `NativeWindowRef` type was removed since it's become redundant now that `NativeWindow` implements `Clone` and `Drop`
- `FdEvent` and `Error` were unused `PollEvent` values which have been removed, considering that we might want to switch to using `epoll` or perhaps `mio` in the future and it's not obvious if these would get in the way.
