### PR TITLE
Allow access to unicode chars for key events

### DIFF
--- a/android-activity/game-activity-csrc/game-activity/GameActivity.cpp
+++ b/android-activity/game-activity-csrc/game-activity/GameActivity.cpp
@@ -1093,6 +1093,7 @@ static struct {
     jmethodID getRepeatCount;
     jmethodID getKeyCode;
     jmethodID getScanCode;
+    jmethodID getUnicodeChar;
 } gKeyEventClassInfo;
 
 extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
@@ -1126,6 +1127,8 @@ extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
             env->GetMethodID(keyEventClass, "getKeyCode", "()I");
         gKeyEventClassInfo.getScanCode =
             env->GetMethodID(keyEventClass, "getScanCode", "()I");
+        gKeyEventClassInfo.getUnicodeChar =
+            env->GetMethodID(keyEventClass, "getUnicodeChar", "()I");
 
         gKeyEventClassInfoInitialized = true;
     }
@@ -1152,7 +1155,9 @@ extern "C" void GameActivityKeyEvent_fromJava(JNIEnv *env, jobject keyEvent,
         /*keyCode=*/
         env->CallIntMethod(keyEvent, gKeyEventClassInfo.getKeyCode),
         /*scanCode=*/
-        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getScanCode)};
+        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getScanCode),
+        /*unicodeChar=*/
+        env->CallIntMethod(keyEvent, gKeyEventClassInfo.getUnicodeChar)};
 }
 
 static bool onTouchEvent_native(JNIEnv *env, jobject javaGameActivity,

--- a/android-activity/game-activity-csrc/game-activity/GameActivity.h
+++ b/android-activity/game-activity-csrc/game-activity/GameActivity.h
@@ -305,6 +305,7 @@ typedef struct GameActivityKeyEvent {
     int32_t repeatCount;
     int32_t keyCode;
     int32_t scanCode;
+    int32_t unicodeChar;
 } GameActivityKeyEvent;
 
 /**

--- a/android-activity/src/game_activity/ffi_aarch64.rs
+++ b/android-activity/src/game_activity/ffi_aarch64.rs
@@ -3511,6 +3511,7 @@ pub struct GameActivityKeyEvent {
     pub repeatCount: i32,
     pub keyCode: i32,
     pub scanCode: i32,
+    pub unicodeChar: i32,
 }
 #[test]
 fn bindgen_test_layout_GameActivityKeyEvent() {

--- a/android-activity/src/game_activity/ffi_arm.rs
+++ b/android-activity/src/game_activity/ffi_arm.rs
@@ -3530,6 +3530,7 @@ pub struct GameActivityKeyEvent {
     pub repeatCount: i32,
     pub keyCode: i32,
     pub scanCode: i32,
+    pub unicodeChar: i32,
 }
 #[test]
 fn bindgen_test_layout_GameActivityKeyEvent() {

--- a/android-activity/src/game_activity/ffi_i686.rs
+++ b/android-activity/src/game_activity/ffi_i686.rs
@@ -3451,6 +3451,7 @@ pub struct GameActivityKeyEvent {
     pub repeatCount: i32,
     pub keyCode: i32,
     pub scanCode: i32,
+    pub unicodeChar: i32,
 }
 #[test]
 fn bindgen_test_layout_GameActivityKeyEvent() {

--- a/android-activity/src/game_activity/ffi_x86_64.rs
+++ b/android-activity/src/game_activity/ffi_x86_64.rs
@@ -3491,6 +3491,7 @@ pub struct GameActivityKeyEvent {
     pub repeatCount: i32,
     pub keyCode: i32,
     pub scanCode: i32,
+    pub unicodeChar: i32,
 }
 #[test]
 fn bindgen_test_layout_GameActivityKeyEvent() {

--- a/android-activity/src/game_activity/input.rs
+++ b/android-activity/src/game_activity/input.rs
@@ -1385,6 +1385,14 @@ impl KeyEvent {
     pub fn scan_code(&self) -> i32 {
         self.scanCode
     }
+
+    /// Returns the unicode character of this key event.
+    #[inline]
+    pub fn char(&self) -> Option<char> {
+        (self.unicodeChar != 0)
+            .then_some(self.unicodeChar)
+            .and_then(|char| (char as u32).try_into().ok())
+    }
 }
 
 /// Flags associated with [`KeyEvent`].


### PR DESCRIPTION
This gives some basic character events. `bindgen` should probably be run on this PR, but I don't know the magic invocation ;)