### PR TITLE
Add show/hide_soft_input methods + enable `InputEvent` forwards compatibility

### DIFF
--- a/android-activity/src/game_activity/mod.rs
+++ b/android-activity/src/game_activity/mod.rs
@@ -320,6 +320,32 @@ impl AndroidAppInner {
         }
     }
 
+    // TODO: move into a trait
+    pub fn show_soft_input(&self, show_implicit: bool) {
+        unsafe {
+            let activity = (*self.native_app.as_ptr()).activity;
+            let flags = if show_implicit {
+                ffi::ShowImeFlags_SHOW_IMPLICIT
+            } else {
+                0
+            };
+            ffi::GameActivity_showSoftInput(activity, flags);
+        }
+    }
+
+    // TODO: move into a trait
+    pub fn hide_soft_input(&self, hide_implicit_only: bool) {
+        unsafe {
+            let activity = (*self.native_app.as_ptr()).activity;
+            let flags = if hide_implicit_only {
+                ffi::HideImeFlags_HIDE_IMPLICIT_ONLY
+            } else {
+                0
+            };
+            ffi::GameActivity_hideSoftInput(activity, flags);
+        }
+    }
+
     pub fn enable_motion_axis(&mut self, axis: Axis) {
         unsafe { ffi::GameActivityPointerAxes_enableAxis(axis as i32) }
     }

--- a/android-activity/src/lib.rs
+++ b/android-activity/src/lib.rs
@@ -442,8 +442,33 @@ impl AndroidApp {
         self.inner.write().unwrap().enable_motion_axis(axis);
     }
 
+    /// Disable input axis
+    ///
+    /// To reduce overhead, by default only [`input::Axis::X`] and [`input::Axis::Y`] are enabled
+    /// and other axis should be enabled explicitly.
     pub fn disable_motion_axis(&self, axis: input::Axis) {
         self.inner.write().unwrap().disable_motion_axis(axis);
+    }
+
+    /// Explicitly request that the current input method's soft input area be
+    /// shown to the user, if needed.
+    ///
+    /// Call this if the user interacts with your view in such a way that they
+    /// have expressed they would like to start performing input into it.
+    pub fn show_soft_input(&self, show_implicit: bool) {
+        self.inner.read().unwrap().show_soft_input(show_implicit);
+    }
+
+    /// Request to hide the soft input window from the context of the window
+    /// that is currently accepting input.
+    ///
+    /// This should be called as a result of the user doing some action that
+    /// fairly explicitly requests to have the input window hidden.
+    pub fn hide_soft_input(&self, hide_implicit_only: bool) {
+        self.inner
+            .read()
+            .unwrap()
+            .hide_soft_input(hide_implicit_only);
     }
 
     /// Query and process all out-standing input event

--- a/android-activity/src/native_activity/mod.rs
+++ b/android-activity/src/native_activity/mod.rs
@@ -369,6 +369,32 @@ impl AndroidAppInner {
         }
     }
 
+    // TODO: move into a trait
+    pub fn show_soft_input(&self, show_implicit: bool) {
+        let na = self.native_activity();
+        unsafe {
+            let flags = if show_implicit {
+                ffi::ANATIVEACTIVITY_SHOW_SOFT_INPUT_IMPLICIT
+            } else {
+                0
+            };
+            ffi::ANativeActivity_showSoftInput(na as *mut _, flags);
+        }
+    }
+
+    // TODO: move into a trait
+    pub fn hide_soft_input(&self, hide_implicit_only: bool) {
+        let na = self.native_activity();
+        unsafe {
+            let flags = if hide_implicit_only {
+                ffi::ANATIVEACTIVITY_HIDE_SOFT_INPUT_IMPLICIT_ONLY
+            } else {
+                0
+            };
+            ffi::ANativeActivity_hideSoftInput(na as *mut _, flags);
+        }
+    }
+
     pub fn enable_motion_axis(&self, _axis: input::Axis) {
         // NOP - The InputQueue API doesn't let us optimize which axis values are read
     }


### PR DESCRIPTION
This is intended to be a stepping stone for addressing #18, considering the issues hit when testing https://github.com/rib/android-activity/pull/24