### PR TITLE
game_activity/input: support Pointer::tool_type()

### DIFF
--- a/android-activity/game-activity-csrc/game-activity/GameActivity.cpp
+++ b/android-activity/game-activity-csrc/game-activity/GameActivity.cpp
@@ -890,6 +890,7 @@ static struct {
 
     jmethodID getPointerCount;
     jmethodID getPointerId;
+    jmethodID getToolType;
     jmethodID getRawX;
     jmethodID getRawY;
     jmethodID getXPrecision;
@@ -941,6 +942,8 @@ extern "C" int GameActivityMotionEvent_fromJava(
             env->GetMethodID(motionEventClass, "getPointerCount", "()I");
         gMotionEventClassInfo.getPointerId =
             env->GetMethodID(motionEventClass, "getPointerId", "(I)I");
+        gMotionEventClassInfo.getToolType =
+            env->GetMethodID(motionEventClass, "getToolType", "(I)I");
         if (sdkVersion >= 29) {
             gMotionEventClassInfo.getRawX =
                 env->GetMethodID(motionEventClass, "getRawX", "(I)F");
@@ -1001,6 +1004,8 @@ extern "C" int GameActivityMotionEvent_fromJava(
         out_event->pointers[i] = {
             /*id=*/env->CallIntMethod(motionEvent,
                                       gMotionEventClassInfo.getPointerId, i),
+            /*toolType=*/env->CallIntMethod(motionEvent,
+                                            gMotionEventClassInfo.getToolType, i),
             /*axisValues=*/{0},
             /*rawX=*/gMotionEventClassInfo.getRawX
                 ? env->CallFloatMethod(motionEvent,

--- a/android-activity/game-activity-csrc/game-activity/GameActivity.h
+++ b/android-activity/game-activity-csrc/game-activity/GameActivity.h
@@ -137,6 +137,7 @@ typedef struct GameActivity {
  */
 typedef struct GameActivityPointerAxes {
     int32_t id;
+    int32_t toolType;
     float axisValues[GAME_ACTIVITY_POINTER_INFO_AXIS_COUNT];
     float rawX;
     float rawY;

--- a/android-activity/src/game_activity/ffi_aarch64.rs
+++ b/android-activity/src/game_activity/ffi_aarch64.rs
@@ -2713,6 +2713,7 @@ fn bindgen_test_layout_GameActivity() {
 #[derive(Debug, Copy, Clone)]
 pub struct GameActivityPointerAxes {
     pub id: i32,
+    pub toolType: i32,
     pub axisValues: [f32; 48usize],
     pub rawX: f32,
     pub rawY: f32,
@@ -2721,7 +2722,7 @@ pub struct GameActivityPointerAxes {
 fn bindgen_test_layout_GameActivityPointerAxes() {
     assert_eq!(
         ::std::mem::size_of::<GameActivityPointerAxes>(),
-        204usize,
+        208usize,
         concat!("Size of: ", stringify!(GameActivityPointerAxes))
     );
     assert_eq!(
@@ -2741,9 +2742,21 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<GameActivityPointerAxes>())).axisValues as *const _ as usize
+            &(*(::std::ptr::null::<GameActivityPointerAxes>())).toolType as *const _ as usize
         },
         4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(GameActivityPointerAxes),
+            "::",
+            stringify!(toolType)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<GameActivityPointerAxes>())).axisValues as *const _ as usize
+        },
+        8usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2753,7 +2766,7 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<GameActivityPointerAxes>())).rawX as *const _ as usize },
-        196usize,
+        200usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2763,7 +2776,7 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<GameActivityPointerAxes>())).rawY as *const _ as usize },
-        200usize,
+        204usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2888,7 +2901,7 @@ pub struct GameActivityMotionEvent {
 fn bindgen_test_layout_GameActivityMotionEvent() {
     assert_eq!(
         ::std::mem::size_of::<GameActivityMotionEvent>(),
-        1704usize,
+        1736usize,
         concat!("Size of: ", stringify!(GameActivityMotionEvent))
     );
     assert_eq!(
@@ -3050,7 +3063,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).precisionX as *const _ as usize
         },
-        1692usize,
+        1724usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3062,7 +3075,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).precisionY as *const _ as usize
         },
-        1696usize,
+        1728usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3074,7 +3087,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).historicalStart as *const _ as usize
         },
-        1700usize,
+        1732usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3086,7 +3099,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).historicalCount as *const _ as usize
         },
-        1702usize,
+        1734usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -7208,7 +7221,7 @@ pub struct android_input_buffer {
 fn bindgen_test_layout_android_input_buffer() {
     assert_eq!(
         ::std::mem::size_of::<android_input_buffer>(),
-        40312usize,
+        40824usize,
         concat!("Size of: ", stringify!(android_input_buffer))
     );
     assert_eq!(
@@ -7232,7 +7245,7 @@ fn bindgen_test_layout_android_input_buffer() {
         unsafe {
             &(*(::std::ptr::null::<android_input_buffer>())).motionEventsCount as *const _ as usize
         },
-        27264usize,
+        27776usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7245,7 +7258,7 @@ fn bindgen_test_layout_android_input_buffer() {
             &(*(::std::ptr::null::<android_input_buffer>())).historicalAxisSamples as *const _
                 as usize
         },
-        27272usize,
+        27784usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7258,7 +7271,7 @@ fn bindgen_test_layout_android_input_buffer() {
             &(*(::std::ptr::null::<android_input_buffer>())).historicalSamplesCount as *const _
                 as usize
         },
-        40072usize,
+        40584usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7268,7 +7281,7 @@ fn bindgen_test_layout_android_input_buffer() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_input_buffer>())).keyEvents as *const _ as usize },
-        40080usize,
+        40592usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7280,7 +7293,7 @@ fn bindgen_test_layout_android_input_buffer() {
         unsafe {
             &(*(::std::ptr::null::<android_input_buffer>())).keyEventsCount as *const _ as usize
         },
-        40304usize,
+        40816usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7411,7 +7424,7 @@ pub struct android_app {
 fn bindgen_test_layout_android_app() {
     assert_eq!(
         ::std::mem::size_of::<android_app>(),
-        80912usize,
+        81936usize,
         concat!("Size of: ", stringify!(android_app))
     );
     assert_eq!(
@@ -7541,7 +7554,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).currentInputBuffer as *const _ as usize },
-        80712usize,
+        81736usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7551,7 +7564,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).textInputState as *const _ as usize },
-        80716usize,
+        81740usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7561,7 +7574,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).mutex as *const _ as usize },
-        80720usize,
+        81744usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7571,7 +7584,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).cond as *const _ as usize },
-        80760usize,
+        81784usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7581,7 +7594,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).msgread as *const _ as usize },
-        80808usize,
+        81832usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7591,7 +7604,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).msgwrite as *const _ as usize },
-        80812usize,
+        81836usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7601,7 +7614,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).thread as *const _ as usize },
-        80816usize,
+        81840usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7611,7 +7624,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).cmdPollSource as *const _ as usize },
-        80824usize,
+        81848usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7621,7 +7634,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).running as *const _ as usize },
-        80848usize,
+        81872usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7631,7 +7644,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).stateSaved as *const _ as usize },
-        80852usize,
+        81876usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7641,7 +7654,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).destroyed as *const _ as usize },
-        80856usize,
+        81880usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7651,7 +7664,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).redrawNeeded as *const _ as usize },
-        80860usize,
+        81884usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7661,7 +7674,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).pendingWindow as *const _ as usize },
-        80864usize,
+        81888usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7671,7 +7684,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).pendingContentRect as *const _ as usize },
-        80872usize,
+        81896usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7681,7 +7694,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).keyEventFilter as *const _ as usize },
-        80888usize,
+        81912usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7691,7 +7704,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).motionEventFilter as *const _ as usize },
-        80896usize,
+        81920usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7703,7 +7716,7 @@ fn bindgen_test_layout_android_app() {
         unsafe {
             &(*(::std::ptr::null::<android_app>())).inputAvailableWakeUp as *const _ as usize
         },
-        80904usize,
+        81928usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -7713,7 +7726,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).inputSwapPending as *const _ as usize },
-        80905usize,
+        81929usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),

--- a/android-activity/src/game_activity/ffi_arm.rs
+++ b/android-activity/src/game_activity/ffi_arm.rs
@@ -2743,6 +2743,7 @@ fn bindgen_test_layout_GameActivity() {
 #[derive(Debug, Copy, Clone)]
 pub struct GameActivityPointerAxes {
     pub id: i32,
+    pub toolType: i32,
     pub axisValues: [f32; 48usize],
     pub rawX: f32,
     pub rawY: f32,
@@ -2751,7 +2752,7 @@ pub struct GameActivityPointerAxes {
 fn bindgen_test_layout_GameActivityPointerAxes() {
     assert_eq!(
         ::std::mem::size_of::<GameActivityPointerAxes>(),
-        204usize,
+        208usize,
         concat!("Size of: ", stringify!(GameActivityPointerAxes))
     );
     assert_eq!(
@@ -2771,9 +2772,21 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<GameActivityPointerAxes>())).axisValues as *const _ as usize
+            &(*(::std::ptr::null::<GameActivityPointerAxes>())).toolType as *const _ as usize
         },
         4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(GameActivityPointerAxes),
+            "::",
+            stringify!(toolType)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<GameActivityPointerAxes>())).axisValues as *const _ as usize
+        },
+        8usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2783,7 +2796,7 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<GameActivityPointerAxes>())).rawX as *const _ as usize },
-        196usize,
+        200usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2793,7 +2806,7 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<GameActivityPointerAxes>())).rawY as *const _ as usize },
-        200usize,
+        204usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2918,7 +2931,7 @@ pub struct GameActivityMotionEvent {
 fn bindgen_test_layout_GameActivityMotionEvent() {
     assert_eq!(
         ::std::mem::size_of::<GameActivityMotionEvent>(),
-        1704usize,
+        1736usize,
         concat!("Size of: ", stringify!(GameActivityMotionEvent))
     );
     assert_eq!(
@@ -3080,7 +3093,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).precisionX as *const _ as usize
         },
-        1692usize,
+        1724usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3092,7 +3105,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).precisionY as *const _ as usize
         },
-        1696usize,
+        1728usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3104,7 +3117,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).historicalStart as *const _ as usize
         },
-        1700usize,
+        1732usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3116,7 +3129,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).historicalCount as *const _ as usize
         },
-        1702usize,
+        1734usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -7688,7 +7701,7 @@ pub struct android_input_buffer {
 fn bindgen_test_layout_android_input_buffer() {
     assert_eq!(
         ::std::mem::size_of::<android_input_buffer>(),
-        40312usize,
+        40824usize,
         concat!("Size of: ", stringify!(android_input_buffer))
     );
     assert_eq!(
@@ -7712,7 +7725,7 @@ fn bindgen_test_layout_android_input_buffer() {
         unsafe {
             &(*(::std::ptr::null::<android_input_buffer>())).motionEventsCount as *const _ as usize
         },
-        27264usize,
+        27776usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7725,7 +7738,7 @@ fn bindgen_test_layout_android_input_buffer() {
             &(*(::std::ptr::null::<android_input_buffer>())).historicalAxisSamples as *const _
                 as usize
         },
-        27272usize,
+        27784usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7738,7 +7751,7 @@ fn bindgen_test_layout_android_input_buffer() {
             &(*(::std::ptr::null::<android_input_buffer>())).historicalSamplesCount as *const _
                 as usize
         },
-        40072usize,
+        40584usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7748,7 +7761,7 @@ fn bindgen_test_layout_android_input_buffer() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_input_buffer>())).keyEvents as *const _ as usize },
-        40080usize,
+        40592usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7760,7 +7773,7 @@ fn bindgen_test_layout_android_input_buffer() {
         unsafe {
             &(*(::std::ptr::null::<android_input_buffer>())).keyEventsCount as *const _ as usize
         },
-        40304usize,
+        40816usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -7891,7 +7904,7 @@ pub struct android_app {
 fn bindgen_test_layout_android_app() {
     assert_eq!(
         ::std::mem::size_of::<android_app>(),
-        80768usize,
+        81792usize,
         concat!("Size of: ", stringify!(android_app))
     );
     assert_eq!(
@@ -8021,7 +8034,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).currentInputBuffer as *const _ as usize },
-        80680usize,
+        81704usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8031,7 +8044,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).textInputState as *const _ as usize },
-        80684usize,
+        81708usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8041,7 +8054,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).mutex as *const _ as usize },
-        80688usize,
+        81712usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8051,7 +8064,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).cond as *const _ as usize },
-        80692usize,
+        81716usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8061,7 +8074,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).msgread as *const _ as usize },
-        80696usize,
+        81720usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8071,7 +8084,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).msgwrite as *const _ as usize },
-        80700usize,
+        81724usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8081,7 +8094,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).thread as *const _ as usize },
-        80704usize,
+        81728usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8091,7 +8104,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).cmdPollSource as *const _ as usize },
-        80708usize,
+        81732usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8101,7 +8114,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).running as *const _ as usize },
-        80720usize,
+        81744usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8111,7 +8124,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).stateSaved as *const _ as usize },
-        80724usize,
+        81748usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8121,7 +8134,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).destroyed as *const _ as usize },
-        80728usize,
+        81752usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8131,7 +8144,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).redrawNeeded as *const _ as usize },
-        80732usize,
+        81756usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8141,7 +8154,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).pendingWindow as *const _ as usize },
-        80736usize,
+        81760usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8151,7 +8164,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).pendingContentRect as *const _ as usize },
-        80740usize,
+        81764usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8161,7 +8174,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).keyEventFilter as *const _ as usize },
-        80756usize,
+        81780usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8171,7 +8184,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).motionEventFilter as *const _ as usize },
-        80760usize,
+        81784usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8183,7 +8196,7 @@ fn bindgen_test_layout_android_app() {
         unsafe {
             &(*(::std::ptr::null::<android_app>())).inputAvailableWakeUp as *const _ as usize
         },
-        80764usize,
+        81788usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -8193,7 +8206,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).inputSwapPending as *const _ as usize },
-        80765usize,
+        81789usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),

--- a/android-activity/src/game_activity/ffi_i686.rs
+++ b/android-activity/src/game_activity/ffi_i686.rs
@@ -2664,6 +2664,7 @@ fn bindgen_test_layout_GameActivity() {
 #[derive(Debug, Copy, Clone)]
 pub struct GameActivityPointerAxes {
     pub id: i32,
+    pub toolType: i32,
     pub axisValues: [f32; 48usize],
     pub rawX: f32,
     pub rawY: f32,
@@ -2672,7 +2673,7 @@ pub struct GameActivityPointerAxes {
 fn bindgen_test_layout_GameActivityPointerAxes() {
     assert_eq!(
         ::std::mem::size_of::<GameActivityPointerAxes>(),
-        204usize,
+        208usize,
         concat!("Size of: ", stringify!(GameActivityPointerAxes))
     );
     assert_eq!(
@@ -2692,9 +2693,21 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<GameActivityPointerAxes>())).axisValues as *const _ as usize
+            &(*(::std::ptr::null::<GameActivityPointerAxes>())).toolType as *const _ as usize
         },
         4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(GameActivityPointerAxes),
+            "::",
+            stringify!(toolType)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<GameActivityPointerAxes>())).axisValues as *const _ as usize
+        },
+        8usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2704,7 +2717,7 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<GameActivityPointerAxes>())).rawX as *const _ as usize },
-        196usize,
+        200usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2714,7 +2727,7 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<GameActivityPointerAxes>())).rawY as *const _ as usize },
-        200usize,
+        204usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2839,7 +2852,7 @@ pub struct GameActivityMotionEvent {
 fn bindgen_test_layout_GameActivityMotionEvent() {
     assert_eq!(
         ::std::mem::size_of::<GameActivityMotionEvent>(),
-        1700usize,
+        1732usize,
         concat!("Size of: ", stringify!(GameActivityMotionEvent))
     );
     assert_eq!(
@@ -3001,7 +3014,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).precisionX as *const _ as usize
         },
-        1688usize,
+        1720usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3013,7 +3026,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).precisionY as *const _ as usize
         },
-        1692usize,
+        1724usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3025,7 +3038,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).historicalStart as *const _ as usize
         },
-        1696usize,
+        1728usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3037,7 +3050,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).historicalCount as *const _ as usize
         },
-        1698usize,
+        1730usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -9433,7 +9446,7 @@ pub struct android_input_buffer {
 fn bindgen_test_layout_android_input_buffer() {
     assert_eq!(
         ::std::mem::size_of::<android_input_buffer>(),
-        40232usize,
+        40744usize,
         concat!("Size of: ", stringify!(android_input_buffer))
     );
     assert_eq!(
@@ -9457,7 +9470,7 @@ fn bindgen_test_layout_android_input_buffer() {
         unsafe {
             &(*(::std::ptr::null::<android_input_buffer>())).motionEventsCount as *const _ as usize
         },
-        27200usize,
+        27712usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9470,7 +9483,7 @@ fn bindgen_test_layout_android_input_buffer() {
             &(*(::std::ptr::null::<android_input_buffer>())).historicalAxisSamples as *const _
                 as usize
         },
-        27208usize,
+        27720usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9483,7 +9496,7 @@ fn bindgen_test_layout_android_input_buffer() {
             &(*(::std::ptr::null::<android_input_buffer>())).historicalSamplesCount as *const _
                 as usize
         },
-        40008usize,
+        40520usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9493,7 +9506,7 @@ fn bindgen_test_layout_android_input_buffer() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_input_buffer>())).keyEvents as *const _ as usize },
-        40016usize,
+        40528usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9505,7 +9518,7 @@ fn bindgen_test_layout_android_input_buffer() {
         unsafe {
             &(*(::std::ptr::null::<android_input_buffer>())).keyEventsCount as *const _ as usize
         },
-        40224usize,
+        40736usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9636,7 +9649,7 @@ pub struct android_app {
 fn bindgen_test_layout_android_app() {
     assert_eq!(
         ::std::mem::size_of::<android_app>(),
-        80608usize,
+        81632usize,
         concat!("Size of: ", stringify!(android_app))
     );
     assert_eq!(
@@ -9766,7 +9779,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).currentInputBuffer as *const _ as usize },
-        80520usize,
+        81544usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9776,7 +9789,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).textInputState as *const _ as usize },
-        80524usize,
+        81548usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9786,7 +9799,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).mutex as *const _ as usize },
-        80528usize,
+        81552usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9796,7 +9809,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).cond as *const _ as usize },
-        80532usize,
+        81556usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9806,7 +9819,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).msgread as *const _ as usize },
-        80536usize,
+        81560usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9816,7 +9829,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).msgwrite as *const _ as usize },
-        80540usize,
+        81564usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9826,7 +9839,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).thread as *const _ as usize },
-        80544usize,
+        81568usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9836,7 +9849,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).cmdPollSource as *const _ as usize },
-        80548usize,
+        81572usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9846,7 +9859,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).running as *const _ as usize },
-        80560usize,
+        81584usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9856,7 +9869,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).stateSaved as *const _ as usize },
-        80564usize,
+        81588usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9866,7 +9879,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).destroyed as *const _ as usize },
-        80568usize,
+        81592usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9876,7 +9889,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).redrawNeeded as *const _ as usize },
-        80572usize,
+        81596usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9886,7 +9899,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).pendingWindow as *const _ as usize },
-        80576usize,
+        81600usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9896,7 +9909,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).pendingContentRect as *const _ as usize },
-        80580usize,
+        81604usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9906,7 +9919,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).keyEventFilter as *const _ as usize },
-        80596usize,
+        81620usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9916,7 +9929,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).motionEventFilter as *const _ as usize },
-        80600usize,
+        81624usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9928,7 +9941,7 @@ fn bindgen_test_layout_android_app() {
         unsafe {
             &(*(::std::ptr::null::<android_app>())).inputAvailableWakeUp as *const _ as usize
         },
-        80604usize,
+        81628usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9938,7 +9951,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).inputSwapPending as *const _ as usize },
-        80605usize,
+        81629usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),

--- a/android-activity/src/game_activity/ffi_x86_64.rs
+++ b/android-activity/src/game_activity/ffi_x86_64.rs
@@ -2693,6 +2693,7 @@ fn bindgen_test_layout_GameActivity() {
 #[derive(Debug, Copy, Clone)]
 pub struct GameActivityPointerAxes {
     pub id: i32,
+    pub toolType: i32,
     pub axisValues: [f32; 48usize],
     pub rawX: f32,
     pub rawY: f32,
@@ -2701,7 +2702,7 @@ pub struct GameActivityPointerAxes {
 fn bindgen_test_layout_GameActivityPointerAxes() {
     assert_eq!(
         ::std::mem::size_of::<GameActivityPointerAxes>(),
-        204usize,
+        208usize,
         concat!("Size of: ", stringify!(GameActivityPointerAxes))
     );
     assert_eq!(
@@ -2721,9 +2722,21 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<GameActivityPointerAxes>())).axisValues as *const _ as usize
+            &(*(::std::ptr::null::<GameActivityPointerAxes>())).toolType as *const _ as usize
         },
         4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(GameActivityPointerAxes),
+            "::",
+            stringify!(toolType)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<GameActivityPointerAxes>())).axisValues as *const _ as usize
+        },
+        8usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2733,7 +2746,7 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<GameActivityPointerAxes>())).rawX as *const _ as usize },
-        196usize,
+        200usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2743,7 +2756,7 @@ fn bindgen_test_layout_GameActivityPointerAxes() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<GameActivityPointerAxes>())).rawY as *const _ as usize },
-        200usize,
+        204usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityPointerAxes),
@@ -2868,7 +2881,7 @@ pub struct GameActivityMotionEvent {
 fn bindgen_test_layout_GameActivityMotionEvent() {
     assert_eq!(
         ::std::mem::size_of::<GameActivityMotionEvent>(),
-        1704usize,
+        1736usize,
         concat!("Size of: ", stringify!(GameActivityMotionEvent))
     );
     assert_eq!(
@@ -3030,7 +3043,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).precisionX as *const _ as usize
         },
-        1692usize,
+        1724usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3042,7 +3055,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).precisionY as *const _ as usize
         },
-        1696usize,
+        1728usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3054,7 +3067,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).historicalStart as *const _ as usize
         },
-        1700usize,
+        1732usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -3066,7 +3079,7 @@ fn bindgen_test_layout_GameActivityMotionEvent() {
         unsafe {
             &(*(::std::ptr::null::<GameActivityMotionEvent>())).historicalCount as *const _ as usize
         },
-        1702usize,
+        1734usize,
         concat!(
             "Offset of field: ",
             stringify!(GameActivityMotionEvent),
@@ -9451,7 +9464,7 @@ pub struct android_input_buffer {
 fn bindgen_test_layout_android_input_buffer() {
     assert_eq!(
         ::std::mem::size_of::<android_input_buffer>(),
-        40312usize,
+        40824usize,
         concat!("Size of: ", stringify!(android_input_buffer))
     );
     assert_eq!(
@@ -9475,7 +9488,7 @@ fn bindgen_test_layout_android_input_buffer() {
         unsafe {
             &(*(::std::ptr::null::<android_input_buffer>())).motionEventsCount as *const _ as usize
         },
-        27264usize,
+        27776usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9488,7 +9501,7 @@ fn bindgen_test_layout_android_input_buffer() {
             &(*(::std::ptr::null::<android_input_buffer>())).historicalAxisSamples as *const _
                 as usize
         },
-        27272usize,
+        27784usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9501,7 +9514,7 @@ fn bindgen_test_layout_android_input_buffer() {
             &(*(::std::ptr::null::<android_input_buffer>())).historicalSamplesCount as *const _
                 as usize
         },
-        40072usize,
+        40584usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9511,7 +9524,7 @@ fn bindgen_test_layout_android_input_buffer() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_input_buffer>())).keyEvents as *const _ as usize },
-        40080usize,
+        40592usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9523,7 +9536,7 @@ fn bindgen_test_layout_android_input_buffer() {
         unsafe {
             &(*(::std::ptr::null::<android_input_buffer>())).keyEventsCount as *const _ as usize
         },
-        40304usize,
+        40816usize,
         concat!(
             "Offset of field: ",
             stringify!(android_input_buffer),
@@ -9654,7 +9667,7 @@ pub struct android_app {
 fn bindgen_test_layout_android_app() {
     assert_eq!(
         ::std::mem::size_of::<android_app>(),
-        80912usize,
+        81936usize,
         concat!("Size of: ", stringify!(android_app))
     );
     assert_eq!(
@@ -9784,7 +9797,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).currentInputBuffer as *const _ as usize },
-        80712usize,
+        81736usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9794,7 +9807,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).textInputState as *const _ as usize },
-        80716usize,
+        81740usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9804,7 +9817,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).mutex as *const _ as usize },
-        80720usize,
+        81744usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9814,7 +9827,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).cond as *const _ as usize },
-        80760usize,
+        81784usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9824,7 +9837,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).msgread as *const _ as usize },
-        80808usize,
+        81832usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9834,7 +9847,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).msgwrite as *const _ as usize },
-        80812usize,
+        81836usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9844,7 +9857,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).thread as *const _ as usize },
-        80816usize,
+        81840usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9854,7 +9867,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).cmdPollSource as *const _ as usize },
-        80824usize,
+        81848usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9864,7 +9877,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).running as *const _ as usize },
-        80848usize,
+        81872usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9874,7 +9887,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).stateSaved as *const _ as usize },
-        80852usize,
+        81876usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9884,7 +9897,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).destroyed as *const _ as usize },
-        80856usize,
+        81880usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9894,7 +9907,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).redrawNeeded as *const _ as usize },
-        80860usize,
+        81884usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9904,7 +9917,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).pendingWindow as *const _ as usize },
-        80864usize,
+        81888usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9914,7 +9927,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).pendingContentRect as *const _ as usize },
-        80872usize,
+        81896usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9924,7 +9937,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).keyEventFilter as *const _ as usize },
-        80888usize,
+        81912usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9934,7 +9947,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).motionEventFilter as *const _ as usize },
-        80896usize,
+        81920usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9946,7 +9959,7 @@ fn bindgen_test_layout_android_app() {
         unsafe {
             &(*(::std::ptr::null::<android_app>())).inputAvailableWakeUp as *const _ as usize
         },
-        80904usize,
+        81928usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),
@@ -9956,7 +9969,7 @@ fn bindgen_test_layout_android_app() {
     );
     assert_eq!(
         unsafe { &(*(::std::ptr::null::<android_app>())).inputSwapPending as *const _ as usize },
-        80905usize,
+        81929usize,
         concat!(
             "Offset of field: ",
             stringify!(android_app),

--- a/android-activity/src/game_activity/input.rs
+++ b/android-activity/src/game_activity/input.rs
@@ -269,6 +269,20 @@ pub enum Axis {
     Generic16 = ndk_sys::AMOTION_EVENT_AXIS_GENERIC_16,
 }
 
+/// The tool type of a pointer.
+///
+/// See [the NDK docs](https://developer.android.com/ndk/reference/group/input#anonymous-enum-48)
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
+#[repr(u32)]
+pub enum ToolType {
+    Unknown = ndk_sys::AMOTION_EVENT_TOOL_TYPE_UNKNOWN,
+    Finger = ndk_sys::AMOTION_EVENT_TOOL_TYPE_FINGER,
+    Stylus = ndk_sys::AMOTION_EVENT_TOOL_TYPE_STYLUS,
+    Mouse = ndk_sys::AMOTION_EVENT_TOOL_TYPE_MOUSE,
+    Eraser = ndk_sys::AMOTION_EVENT_TOOL_TYPE_ERASER,
+    Palm = ndk_sys::AMOTION_EVENT_TOOL_TYPE_PALM,
+}
+
 /// A bitfield representing the state of buttons during a motion event.
 ///
 /// See [the NDK docs](https://developer.android.com/ndk/reference/group/input#anonymous-enum-33)
@@ -632,6 +646,13 @@ impl<'a> Pointer<'a> {
     #[inline]
     pub fn touch_minor(&self) -> f32 {
         self.axis_value(Axis::TouchMinor)
+    }
+
+    #[inline]
+    pub fn tool_type(&self) -> ToolType {
+        let pointer = &self.event.pointers[self.index];
+        let tool_type = pointer.toolType as u32;
+        tool_type.try_into().unwrap()
     }
 }
 


### PR DESCRIPTION
This maintains compatibility with the `ndk` crate's `Pointer` API

Ref: https://github.com/rust-windowing/android-ndk-rs/pull/323

This will also be required for enabling pen pressure support to
Winit, re: https://github.com/rust-windowing/winit/pull/2396